### PR TITLE
chore: update cert-manager to v1.19.1

### DIFF
--- a/charts/cert-manager/fleet.yaml
+++ b/charts/cert-manager/fleet.yaml
@@ -2,7 +2,7 @@ defaultNamespace: cert-manager
 helm:
   repo: https://charts.jetstack.io
   chart: cert-manager
-  version: 1.17.2
+  version: 1.19.1
   valuesFiles:
   - ./values.yaml
   releaseName: cert-manager


### PR DESCRIPTION
## Summary
Updates cert-manager from v1.17.2 to v1.19.1

## Priority Level
🔴 CRITICAL

## Change Details
- **Type:** Helm Chart Version Update
- **Current Version:** 1.17.2
- **New Version:** 1.19.1
- **Version Gap:** 2 minor versions

## Why This Update?
CRITICAL - CVE fixes in certificate management. cert-manager requires updates for security patches.

## Files Modified
- `charts/cert-manager/fleet.yaml`

## Testing Recommendations
- Monitor upgrade: `kubectl get pods -n cert-manager -w`
- Verify certificate renewals: `kubectl get certificates --all-namespaces`
- Check certificate status: `kubectl describe certificate moria-lab-cert -n cert-manager`

## Rollback Plan
Revert this PR merge commit via git revert

## References
- Platform Audit: PLATFORM_AUDIT_RECOMMENDATIONS.md (Task 2.1)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>