### PR TITLE
chore: update Home Assistant container image to v2025.11.0

### DIFF
--- a/charts/ha/deployment.yaml
+++ b/charts/ha/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: home-assistant
-          image: ghcr.io/home-assistant/home-assistant:2024.9.3
+          image: ghcr.io/home-assistant/home-assistant:2025.11.0
           resources:
             requests:
               memory: "128Mi"


### PR DESCRIPTION
## Summary
Updates Home Assistant container image from 2024.9.3 to 2025.11.0

## Priority Level
🔴 CRITICAL

## Change Details
- **Type:** Container Image Update
- **Current Version:** 2024.9.3 (September 2024)
- **New Version:** 2025.11.0 (November 2025)
- **Version Gap:** 14 months of security patches

## Why This Update?
CRITICAL - 14 months of security patches missing. Known CVEs unpatched with potential remote code execution risks.

## Files Modified
- `charts/ha/deployment.yaml`

## Testing Recommendations
- Monitor logs: `kubectl logs -n ha deployment/home-assistant -f`
- Verify Home Assistant UI accessible at `ha.moria-lab.com`
- Test critical automations and integrations
- Verify MQTT connectivity
- Test Zigbee and Z-Wave device control

## Rollback Plan
Revert this PR merge commit via git revert. Fleet will redeploy previous version.

## References
- Platform Audit: PLATFORM_AUDIT_RECOMMENDATIONS.md (Task 1.1)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>