### PR TITLE
chore: update kube-prometheus-stack to v79.0.1

### DIFF
--- a/charts/kube-prometheus-stack/fleet.yaml
+++ b/charts/kube-prometheus-stack/fleet.yaml
@@ -2,7 +2,7 @@ defaultNamespace: monitoring
 helm:
   repo: https://prometheus-community.github.io/helm-charts
   chart: kube-prometheus-stack
-  version: 69.2.4
+  version: 79.0.1
   valuesFiles:
   - ./values.yaml
   releaseName: prometheus-community


### PR DESCRIPTION
## Summary
Updates kube-prometheus-stack from v69.2.4 to v79.0.1

## Priority Level
🟡 HIGH

## Change Details
- **Type:** Helm Chart Version Update
- **Current Version:** 69.2.4
- **New Version:** 79.0.1
- **Version Gap:** 10 minor versions

## Why This Update?
HIGH - Monitoring updates including Prometheus version updates, Grafana version updates, and alert rule changes.

## Files Modified
- `charts/kube-prometheus-stack/fleet.yaml`

## Testing Recommendations
- Monitor upgrade: `kubectl get pods -n monitoring -w`
- Wait for all components to be ready: Prometheus Operator, Prometheus, Alertmanager, Grafana, Node Exporter, Kube State Metrics
- Verify Grafana access: `grafana.moria-lab.com`
- Check Prometheus targets are scraping
- Verify existing dashboards still work

## Rollback Plan
Revert this PR merge commit via git revert. Check if dashboards need restoration.

## References
- Platform Audit: PLATFORM_AUDIT_RECOMMENDATIONS.md (Task 2.4)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>