### PR TITLE
chore: update zigbee2mqtt to v2.6.2

### DIFF
--- a/charts/z2m/fleet.yaml
+++ b/charts/z2m/fleet.yaml
@@ -2,7 +2,7 @@ defaultNamespace: zigbee
 helm:
   repo: https://charts.zigbee2mqtt.io
   chart: zigbee2mqtt
-  version: 2.4.0
+  version: 2.6.2
   releaseName: z2m
   valuesFiles:
   - ./values.yaml


### PR DESCRIPTION
## Summary
Updates zigbee2mqtt from v2.4.0 to v2.6.2

## Priority Level
🟢 MEDIUM

## Change Details
- **Type:** Helm Chart Version Update
- **Current Version:** 2.4.0
- **New Version:** 2.6.2
- **Version Gap:** 2 patch versions

## Why This Update?
MEDIUM - Patch version updates for bug fixes and improvements.

## Files Modified
- `charts/z2m/fleet.yaml`

## Testing Recommendations
- Monitor deployment: `kubectl get pods -n zigbee -w`
- Check logs: `kubectl logs -n zigbee deployment/z2m -f`
- Verify Zigbee devices remain paired: Access Z2M UI at `z2m.moria-lab.com`
- Test device control

## Rollback Plan
Revert this PR merge commit via git revert

## References
- Platform Audit: PLATFORM_AUDIT_RECOMMENDATIONS.md (Task 3.1)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>