### PR TITLE
chore: upgrade Traefik to v37.2.0 with syntax migration

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -138,7 +138,7 @@ charts/<app>/
 | Application | Version | Purpose | Namespace |
 |-------------|---------|---------|-----------|
 | **cert-manager** | v1.17.2 | SSL certificate automation with Let's Encrypt | `cert-manager` |
-| **traefik** | v33.2.1 | Reverse proxy, load balancer, and ingress controller | `traefik-system` |
+| **traefik** | v37.2.0 | Reverse proxy, load balancer, and ingress controller | `traefik-system` |
 | **longhorn** | v1.8.1 | Distributed block storage with 2-replica HA | `longhorn-system` |
 
 ### Dashboard & Management

--- a/charts/traefik/fleet.yaml
+++ b/charts/traefik/fleet.yaml
@@ -2,7 +2,7 @@ defaultNamespace: traefik-system
 helm:
   repo: https://traefik.github.io/charts
   chart: traefik
-  version: 33.2.1
+  version: 37.2.0
   valuesFiles:
   - ./values.yaml
   releaseName: traefik

--- a/charts/traefik/values.yaml
+++ b/charts/traefik/values.yaml
@@ -23,8 +23,11 @@ updateStrategy:
 
 ports:
   web:
-    redirectTo:
-      port: websecure
+    redirections:
+      entryPoint:
+        to: websecure
+        scheme: https
+        permanent: true
 
 ingressRoute:
   dashboard:


### PR DESCRIPTION
## Summary

Upgrades Traefik Helm chart from v33.2.1 to v37.2.0 by migrating the HTTP→HTTPS redirect configuration to the new syntax introduced in v34.0.0.

## Changes

- **charts/traefik/values.yaml**: Migrated `redirectTo` → `redirections.entryPoint` structure
- **charts/traefik/fleet.yaml**: Updated chart version to v37.2.0
- **Readme.md**: Updated version table to reflect v37.2.0

## Technical Details

### Breaking Change Resolution
The `redirectTo` syntax was removed in Traefik Helm Chart v34.0.0. The new syntax aligns with upstream Traefik Proxy configuration format:

**Before (v33 syntax):**
```yaml
ports:
  web:
    redirectTo:
      port: websecure
```

**After (v34+ syntax):**
```yaml
ports:
  web:
    redirections:
      entryPoint:
        to: websecure
        scheme: https
        permanent: true
```

### References
- [Traefik Helm Chart v34.0.0 Release Notes](https://github.com/traefik/traefik-helm-chart/releases/tag/v34.0.0)
- [PR #1301 - Redirect Syntax Migration](https://github.com/traefik/traefik-helm-chart/pull/1301)
- [Official EXAMPLES.md](https://github.com/traefik/traefik-helm-chart/blob/master/EXAMPLES.md#redirect-permanently-traffic-from-http-to-https)

## Testing

Fleet GitOps will deploy this automatically upon merge. Verify:
- HTTP traffic (port 80) redirects to HTTPS (port 443) with 301 status
- Traefik dashboard remains accessible at `traefik.moria-lab.com`
- All existing IngressRoutes continue functioning
- LoadBalancer IP `192.168.10.35` remains stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)