### PR TITLE
chore: upgrade Longhorn to v1.9.2 with expanded CRD comparePatches

### DIFF
--- a/charts/longhorn/fleet.yaml
+++ b/charts/longhorn/fleet.yaml
@@ -2,7 +2,7 @@ defaultNamespace: longhorn-system
 helm:
   repo: https://charts.longhorn.io
   chart: longhorn
-  version: v1.8.1
+  version: v1.9.2
   releaseName: longhorn
   values:
     persistence:
@@ -24,5 +24,25 @@ diff:
   - apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     name: volumes.longhorn.io
+    operations:
+    - {"op": "replace", "path": "/status"}
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: engines.longhorn.io
+    operations:
+    - {"op": "replace", "path": "/status"}
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: instancemanagers.longhorn.io
+    operations:
+    - {"op": "replace", "path": "/status"}
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: replicas.longhorn.io
+    operations:
+    - {"op": "replace", "path": "/status"}
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: settings.longhorn.io
     operations:
     - {"op": "replace", "path": "/status"}


### PR DESCRIPTION
## Summary

Upgrades Longhorn from v1.8.1 to v1.9.2, adding required CRD comparePatches for v1.9.x compatibility. CRD migration from v1beta1 to v1beta2 happens automatically during Fleet deployment.

## Changes

- **charts/longhorn/fleet.yaml**: Updated Helm chart version from v1.8.1 to v1.9.2
- **charts/longhorn/fleet.yaml**: Added 4 additional CRD comparePatches (engines, instancemanagers, replicas, settings) to existing 3 CRDs

## Technical Details

### Why v1.9.2 Instead of v1.9.3?
Longhorn v1.9.3 does not exist. The latest stable release in the v1.9.x series is v1.9.2 (released September 24, 2024).

### Why Not Skip to v1.10.0?
Longhorn enforces incremental minor version upgrades. The previous attempt (PR #22) failed because it skipped the mandatory v1.9.x intermediate version. The required upgrade path is: v1.8.1 → v1.9.x → v1.10.x (when stable).

### CRD Migration
The upgrade from v1.8.x to v1.9.x automatically migrates Custom Resources from v1beta1 to v1beta2 API versions. No manual CRD migration is required for this upgrade (manual steps are only needed when upgrading from v1.9.x to v1.10.x in the future).

### Fleet Configuration Updates
**Before (3 CRDs):**
- engineimages.longhorn.io
- nodes.longhorn.io
- volumes.longhorn.io

**After (7 CRDs):**
- engineimages.longhorn.io
- nodes.longhorn.io
- volumes.longhorn.io
- engines.longhorn.io (added)
- instancemanagers.longhorn.io (added)
- replicas.longhorn.io (added)
- settings.longhorn.io (added)

### References
- [Longhorn v1.9.2 Release Notes](https://github.com/longhorn/longhorn/releases/tag/v1.9.2)
- [Longhorn v1.9.0 Important Notes](https://longhorn.io/docs/1.9.0/important-notes/)
- [Longhorn Upgrade Documentation](https://longhorn.io/docs/1.9.2/deploy/upgrade/)

## Testing

Fleet GitOps will deploy this automatically upon merge. Verify:

**Pre-Merge:**
- [ ] Kubernetes cluster is v1.25 or later
- [ ] All Longhorn pods are Running (`kubectl -n longhorn-system get pods`)
- [ ] No volumes in Faulted state
- [ ] Longhorn system backup created via UI

**Post-Merge (Automatic via Fleet):**
- [ ] Fleet detects git change and triggers Helm upgrade
- [ ] Longhorn pre-upgrade job validates upgrade path
- [ ] Manager pods restart with v1.9.2
- [ ] All pods reach Running state
- [ ] CRDs migrated to v1beta2 (`kubectl get crd volumes.longhorn.io -o jsonpath='{.status.storedVersions}'` shows `["v1beta2"]`)

**Manual Post-Upgrade:**
- [ ] Upgrade Longhorn Engine to v1.9.2 via UI (volume by volume) or enable automatic engine upgrade
- [ ] Verify all volumes healthy
- [ ] Test PVC creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)