### PR TITLE
fix: disable kubeScheduler and kubeControllerManager monitoring for K3s

### DIFF
--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -20,6 +20,7 @@ defaultRules:
     kubernetesResources: true
     kubernetesStorage: true
     kubernetesSystem: true
+    kubeControllerManager: false
     kubeScheduler: false
     kubeStateMetrics: false
     network: false
@@ -82,11 +83,12 @@ kubelet:
         targetLabel: instance
 
 kubeControllerManager:
-  enabled: true
-  endpoints: # ips of servers 
-    - 192.168.10.60
-    - 192.168.10.212
-    - 192.168.10.218
+  enabled: false
+  # Endpoints preserved for future reference if metrics are enabled
+  # endpoints: # ips of servers
+  #   - 192.168.10.60
+  #   - 192.168.10.212
+  #   - 192.168.10.218
 
 coreDns:
   enabled: false
@@ -106,11 +108,12 @@ kubeEtcd:
     targetPort: 2381
 
 kubeScheduler:
-  enabled: true
-  endpoints: # ips of servers
-    - 192.168.10.60
-    - 192.168.10.212
-    - 192.168.10.218
+  enabled: false
+  # Endpoints preserved for future reference if metrics are enabled
+  # endpoints: # ips of servers
+  #   - 192.168.10.60
+  #   - 192.168.10.212
+  #   - 192.168.10.218
 
 kubeProxy:
   enabled: true


### PR DESCRIPTION
## Summary

Disables monitoring for kube-scheduler and kube-controller-manager components to eliminate false positive alerts in K3s clusters. These components run as embedded binaries in the K3s control plane rather than separate pods, making them incompatible with standard Prometheus ServiceMonitor discovery.

## Changes

- **charts/kube-prometheus-stack/values.yaml**: Set `kubeControllerManager.enabled: false` and `kubeScheduler.enabled: false`
- **charts/kube-prometheus-stack/values.yaml**: Comment out endpoint IPs (preserved for future reference)
- **charts/kube-prometheus-stack/values.yaml**: Add explicit `kubeControllerManager: false` in defaultRules section

## Technical Details

### K3s Architecture Difference

K3s runs control plane components as a single binary rather than separate Kubernetes pods. This architectural difference prevents Prometheus from auto-discovering these endpoints, resulting in persistent KubeSchedulerDown and KubeControllerManagerDown alerts despite the cluster functioning correctly.

### References
- [Prometheus for Rancher K3s control plane monitoring - Spectro Cloud](https://www.spectrocloud.com/blog/enabling-rancher-k3s-cluster-control-plane-monitoring-with-prometheus)
- [K3s monitoring example configuration](https://github.com/cablespaghetti/k3s-monitoring/blob/master/kube-prometheus-stack-values.yaml)
- [Best practice prometheus monitoring · Issue #425](https://github.com/k3s-io/k3s/issues/425)

## Testing

Fleet GitOps will deploy this automatically upon merge.

**Note:** Validation will be performed post-deployment to verify alerts are cleared.