### PR TITLE
fix: reduce Loki cache memory to resolve KubeMemoryOvercommit alert

### DIFF
--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -62,7 +62,14 @@ gateway:
 monitoring:
   serviceMonitor:
     enabled: true
-    
+
+# Cache configuration - conservative allocations based on actual usage
+chunksCache:
+  allocatedMemory: 1024  # MB, results in 1229Mi request (1024 * 1.2)
+
+resultsCache:
+  allocatedMemory: 256   # MB, results in 307Mi request (256 * 1.2)
+
 # Test configuration
 test:
   enabled: false


### PR DESCRIPTION
## Summary

Reduces Loki memcached cache memory allocations from 11GB to 1.5GB based on actual usage analysis, freeing ~9.3GB of cluster memory and resolving the KubeMemoryOvercommit alert.

## Changes

- **charts/loki/values.yaml**: Added explicit `chunksCache.allocatedMemory: 1024` and `resultsCache.allocatedMemory: 256` configuration

## Technical Details

### Problem Context

Cluster experiencing KubeMemoryOvercommit alert due to pod memory requests (16.18GB) exceeding safe capacity after node failure tolerance (15.6GB). Loki's memcached caches were over-provisioned:
- loki-chunks-cache-0: 9830Mi requested, 323Mi actual usage (3.3% utilization)
- loki-results-cache-0: 1229Mi requested, 31Mi actual usage (2.5% utilization)
- Total over-allocation: ~11GB

### Solution

Conservative reduction maintaining 3-10x headroom over actual usage:

**Before:**
```yaml
# Helm chart defaults
chunksCache.allocatedMemory: 8192  # → 9830Mi request
resultsCache.allocatedMemory: 1024  # → 1229Mi request
```

**After:**
```yaml
chunksCache:
  allocatedMemory: 1024  # MB → 1229Mi request (3.8x headroom)

resultsCache:
  allocatedMemory: 256   # MB → 307Mi request (10x headroom)
```

### Memory Impact

- Freed memory: 9,523Mi (~9.3GB)
- New cluster utilization: 6.88GB vs 16.18GB
- Alert resolution: 8.7GB buffer under safe capacity threshold

### Sizing Rationale

1. Conservative 3-10x multiplier over actual usage (323Mi chunks, 31Mi results)
2. Based on 169 days production data
3. Homelab scale with single binary mode and 30-day retention
4. Memcached LRU eviction ensures graceful degradation under pressure

### References
- [Grafana Loki Caching Documentation](https://grafana.com/docs/loki/latest/operations/caching/)
- [KubeMemoryOvercommit Runbook](https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubememoryovercommit)

## Testing

Fleet will auto-deploy upon merge. Minimal validation required:

**Post-merge verification (5-10 minutes):**

```bash
# Verify Fleet synced
kubectl get bundledeployments -n fleet-local | grep loki

# Verify memory allocations updated
kubectl get statefulset loki-chunks-cache -n monitoring -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}'
# Expected: 1229Mi (was 9830Mi)

kubectl get statefulset loki-results-cache -n monitoring -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}'
# Expected: 307Mi (was 1229Mi)

# Check pods healthy
kubectl get pods -n monitoring -l app.kubernetes.io/name=loki

# Verify KubeMemoryOvercommit alert cleared (wait 10-15 minutes)
kubectl exec -n monitoring prometheus-kube-prometheus-stack-prometheus-0 -c prometheus -- \
  wget -qO- "localhost:9090/api/v1/query?query=ALERTS%7Balertname%3D%22KubeMemoryOvercommit%22%7D" | jq .
# Should show no active alerts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)