### PR TITLE
feat: add comprehensive Longhorn storage alerting with PrometheusRule monitoring

### DIFF
--- a/charts/kube-prometheus-stack/overlays/dev/kustomization.yaml
+++ b/charts/kube-prometheus-stack/overlays/dev/kustomization.yaml
@@ -6,4 +6,5 @@ namespace: monitoring
 resources:
   - ingress.yaml
   - prometheusrules/gitops-cert-manager-expiration-prometheus.yaml
+  - prometheusrules/longhorn-storage-alerts.yaml
   - alertmanagerconfig-discord.yaml 

--- a/charts/kube-prometheus-stack/overlays/dev/prometheusrules/longhorn-storage-alerts.yaml
+++ b/charts/kube-prometheus-stack/overlays/dev/prometheusrules/longhorn-storage-alerts.yaml
@@ -1,0 +1,240 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: longhorn-storage-alerts
+  namespace: monitoring
+  labels:
+    prometheus: kube-prometheus-stack-prometheus
+    role: alert-rules
+spec:
+  groups:
+    - name: longhorn-volume-health
+      interval: 30s
+      rules:
+        - alert: GitOpsLonghornVolumeFault
+          expr: |
+            longhorn_volume_robustness == 3
+          for: 2m
+          labels:
+            severity: critical
+            component: longhorn
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} is FAULTED"
+            description: "Volume {{ $labels.volume }} on node {{ $labels.node }} is in faulted state and cannot serve I/O. Check volume and replica health immediately."
+
+        - alert: GitOpsLonghornVolumeDegraded
+          expr: |
+            longhorn_volume_robustness == 2
+          for: 5m
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} is DEGRADED"
+            description: "Volume {{ $labels.volume }} is degraded with fewer replicas than configured. With 2-replica HA, this means ZERO redundancy. Immediate attention required."
+
+        - alert: GitOpsLonghornVolumeReadOnly
+          expr: |
+            longhorn_volume_read_only == 1
+          for: 2m
+          labels:
+            severity: critical
+            component: longhorn
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} is READ-ONLY"
+            description: "Volume {{ $labels.volume }} has entered read-only mode due to errors. Applications cannot write data."
+
+    - name: longhorn-replica-health
+      interval: 30s
+      rules:
+        - alert: GitOpsLonghornVolumeReplicaCountCritical
+          expr: |
+            longhorn_volume_replica_count < 2
+          for: 2m
+          labels:
+            severity: critical
+            component: longhorn
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} has CRITICAL replica count"
+            description: "Volume {{ $labels.volume }} has only {{ $value }} replica(s). With 2-replica HA configuration, this means ZERO redundancy. Data loss imminent if remaining replica fails."
+
+        - alert: GitOpsLonghornReplicaRebuildSlow
+          expr: |
+            longhorn_volume_replica_rebuild_progress < 50
+          for: 30m
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "Slow replica rebuild for volume {{ $labels.volume }}"
+            description: "Volume {{ $labels.volume }} replica rebuild is at {{ $value }}% after 30 minutes. Investigate disk I/O or network issues."
+
+    - name: longhorn-capacity
+      interval: 1m
+      rules:
+        - alert: GitOpsLonghornVolumeUsageHigh
+          expr: |
+            (longhorn_volume_actual_size_bytes / longhorn_volume_capacity_bytes) * 100 > 80
+          for: 10m
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} is {{ $value | humanizePercentage }} full"
+            description: "Volume {{ $labels.volume }} is at {{ $value | humanizePercentage }} capacity. Consider expanding or cleaning up data."
+
+        - alert: GitOpsLonghornVolumeUsageCritical
+          expr: |
+            (longhorn_volume_actual_size_bytes / longhorn_volume_capacity_bytes) * 100 > 90
+          for: 5m
+          labels:
+            severity: critical
+            component: longhorn
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} is CRITICALLY full at {{ $value | humanizePercentage }}"
+            description: "Volume {{ $labels.volume }} is at {{ $value | humanizePercentage }} capacity. IMMEDIATE expansion or cleanup required to prevent write failures."
+
+        - alert: GitOpsLonghornNodeStorageWarning
+          expr: |
+            (longhorn_node_storage_usage_bytes / longhorn_node_storage_capacity_bytes) * 100 > 70
+          for: 10m
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "Node {{ $labels.node }} storage at {{ $value | humanizePercentage }}"
+            description: "Node {{ $labels.node }} storage is at {{ $value | humanizePercentage }} capacity. Plan for capacity expansion."
+
+        - alert: GitOpsLonghornNodeStorageCritical
+          expr: |
+            (longhorn_node_storage_usage_bytes / longhorn_node_storage_capacity_bytes) * 100 > 85
+          for: 5m
+          labels:
+            severity: critical
+            component: longhorn
+          annotations:
+            summary: "Node {{ $labels.node }} storage CRITICALLY full at {{ $value | humanizePercentage }}"
+            description: "Node {{ $labels.node }} storage is at {{ $value | humanizePercentage }} capacity. Longhorn cannot schedule new replicas. IMMEDIATE action required."
+
+        - alert: GitOpsLonghornDiskStorageWarning
+          expr: |
+            (longhorn_disk_usage_bytes / longhorn_disk_capacity_bytes) * 100 > 70
+          for: 10m
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "Disk {{ $labels.disk }} on {{ $labels.node }} at {{ $value | humanizePercentage }}"
+            description: "Disk {{ $labels.disk }} on node {{ $labels.node }} is at {{ $value | humanizePercentage }} capacity."
+
+        - alert: GitOpsLonghornDiskStorageCritical
+          expr: |
+            (longhorn_disk_usage_bytes / longhorn_disk_capacity_bytes) * 100 > 85
+          for: 5m
+          labels:
+            severity: critical
+            component: longhorn
+          annotations:
+            summary: "Disk {{ $labels.disk }} on {{ $labels.node }} CRITICALLY full at {{ $value | humanizePercentage }}"
+            description: "Disk {{ $labels.disk }} on node {{ $labels.node }} is at {{ $value | humanizePercentage }} capacity. Cannot schedule replicas on this disk."
+
+    - name: longhorn-node-health
+      interval: 1m
+      rules:
+        - alert: GitOpsLonghornNodeDown
+          expr: |
+            longhorn_node_status{condition="ready"} == 0
+          for: 5m
+          labels:
+            severity: critical
+            component: longhorn
+          annotations:
+            summary: "Longhorn node {{ $labels.node }} is DOWN"
+            description: "Longhorn node {{ $labels.node }} is not ready. Replicas on this node are unavailable."
+
+        - alert: GitOpsLonghornNodeNotSchedulable
+          expr: |
+            longhorn_node_status{condition="schedulable"} == 0
+          for: 10m
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "Longhorn node {{ $labels.node }} is not schedulable"
+            description: "Longhorn node {{ $labels.node }} cannot schedule new replicas. Check node conditions and disk space."
+
+        - alert: GitOpsLonghornNodeCPUHigh
+          expr: |
+            (longhorn_node_cpu_usage_millicpu / longhorn_node_cpu_capacity_millicpu) * 100 > 90
+          for: 15m
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "High CPU usage on Longhorn node {{ $labels.node }}"
+            description: "Node {{ $labels.node }} CPU usage is at {{ $value | humanizePercentage }}. May impact storage performance."
+
+    - name: longhorn-performance
+      interval: 1m
+      rules:
+        - alert: GitOpsLonghornVolumeHighReadLatency
+          expr: |
+            longhorn_volume_read_latency / 1000000 > 20
+          for: 10m
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "High read latency on volume {{ $labels.volume }}"
+            description: "Volume {{ $labels.volume }} has read latency of {{ $value }}ms. Investigate disk I/O or network issues."
+
+        - alert: GitOpsLonghornVolumeHighWriteLatency
+          expr: |
+            longhorn_volume_write_latency / 1000000 > 20
+          for: 10m
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "High write latency on volume {{ $labels.volume }}"
+            description: "Volume {{ $labels.volume }} has write latency of {{ $value }}ms. Investigate disk I/O or network issues."
+
+        - alert: GitOpsLonghornInstanceManagerCPUHigh
+          expr: |
+            (
+              rate(container_cpu_usage_seconds_total{namespace="longhorn-system",pod=~"instance-manager-.*"}[5m])
+              /
+              (container_spec_cpu_quota{namespace="longhorn-system",pod=~"instance-manager-.*"} / 100000)
+            ) > 3
+          for: 10m
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "High CPU on instance manager {{ $labels.pod }}"
+            description: "Instance manager {{ $labels.pod }} CPU usage is {{ $value }}x requested. May indicate I/O bottleneck."
+
+    - name: longhorn-backup
+      interval: 5m
+      rules:
+        - alert: GitOpsLonghornBackupFailed
+          expr: |
+            longhorn_backup_state == 3
+          for: 5m
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "Longhorn backup {{ $labels.backup }} FAILED"
+            description: "Backup {{ $labels.backup }} for volume {{ $labels.volume }} is in error state. Check backup target and logs."
+
+        - alert: GitOpsLonghornBackupStuck
+          expr: |
+            longhorn_backup_state == 1
+          for: 2h
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "Longhorn backup {{ $labels.backup }} stuck in progress"
+            description: "Backup {{ $labels.backup }} for volume {{ $labels.volume }} has been in progress for over 2 hours. Investigate backup target connectivity."

--- a/charts/kube-prometheus-stack/overlays/dev/prometheusrules/longhorn-storage-alerts.yaml
+++ b/charts/kube-prometheus-stack/overlays/dev/prometheusrules/longhorn-storage-alerts.yaml
@@ -219,22 +219,22 @@ spec:
       rules:
         - alert: GitOpsLonghornBackupFailed
           expr: |
-            longhorn_backup_state == 3
+            longhorn_backup_state == 4
           for: 5m
           labels:
             severity: warning
             component: longhorn
           annotations:
             summary: "Longhorn backup {{ $labels.backup }} FAILED"
-            description: "Backup {{ $labels.backup }} for volume {{ $labels.volume }} is in error state. Check backup target and logs."
+            description: "Backup {{ $labels.backup }} for volume {{ $labels.volume }} is in error state (state=4). Check backup target and logs."
 
         - alert: GitOpsLonghornBackupStuck
           expr: |
-            longhorn_backup_state == 1
+            longhorn_backup_state == 2
           for: 2h
           labels:
             severity: warning
             component: longhorn
           annotations:
             summary: "Longhorn backup {{ $labels.backup }} stuck in progress"
-            description: "Backup {{ $labels.backup }} for volume {{ $labels.volume }} has been in progress for over 2 hours. Investigate backup target connectivity."
+            description: "Backup {{ $labels.backup }} for volume {{ $labels.volume }} has been in InProgress state for over 2 hours. Investigate backup target connectivity."

--- a/charts/longhorn/fleet.yaml
+++ b/charts/longhorn/fleet.yaml
@@ -7,6 +7,8 @@ helm:
   values:
     persistence:
       defaultClassReplicaCount: 2
+  valuesFiles:
+  - ./values.yaml
 kustomize:
   dir: overlays/dev
 diff:

--- a/charts/longhorn/values.yaml
+++ b/charts/longhorn/values.yaml
@@ -1,0 +1,4 @@
+# Enable Prometheus ServiceMonitor for metrics scraping
+metrics:
+  serviceMonitor:
+    enabled: true


### PR DESCRIPTION
## Summary

Implements comprehensive Longhorn v1.9.2 storage monitoring with 19 PrometheusRule alerts covering volume health, replica management, capacity, node health, performance, and backup monitoring. Integrates with existing kube-prometheus-stack and Discord alerting.

## Changes

- **charts/longhorn/values.yaml**: Enable Prometheus ServiceMonitor for metrics collection
- **charts/longhorn/fleet.yaml**: Add valuesFiles reference to include values.yaml
- **charts/kube-prometheus-stack/overlays/dev/prometheusrules/longhorn-storage-alerts.yaml**: Create 19 alerts across 6 rule groups (volume-health, replica-health, capacity, node-health, performance, backup)
- **charts/kube-prometheus-stack/overlays/dev/kustomization.yaml**: Add longhorn-storage-alerts.yaml to resources
- **CLAUDE.md**: Document Longhorn monitoring configuration, backup state values, and alert naming conventions

## Technical Details

### ServiceMonitor Enablement

Longhorn v1.9.2 requires explicit Helm configuration to expose Prometheus metrics:

```yaml
# charts/longhorn/values.yaml
metrics:
  serviceMonitor:
    enabled: true
```

This creates `longhorn-prometheus-servicemonitor` in the `longhorn-system` namespace, exposing metrics on port 9500.

### Alert Structure

**19 alerts organized into 6 groups:**
- **longhorn-volume-health** (3 alerts): Volume fault, degraded, read-only states
- **longhorn-replica-health** (2 alerts): Replica count critical, rebuild slow
- **longhorn-capacity** (6 alerts): Volume/node/disk storage warnings and critical thresholds
- **longhorn-node-health** (3 alerts): Node down, not schedulable, high CPU
- **longhorn-performance** (3 alerts): High read/write latency, instance manager CPU
- **longhorn-backup** (2 alerts): Backup failed, backup stuck in progress

All alerts follow GitOps naming convention with "GitOps" prefix (e.g., `GitOpsLonghornVolumeFault`) and include `component: longhorn` label for Discord routing.

### Backup State Correction

**Critical fix:** Longhorn changed backup state values in v1.3.0+:

**Before (incorrect):**
```yaml
- alert: GitOpsLonghornBackupFailed
  expr: |
    longhorn_backup_state == 3  # Wrong - 3 = Completed
```

**After (correct):**
```yaml
- alert: GitOpsLonghornBackupFailed
  expr: |
    longhorn_backup_state == 4  # Correct - 4 = Error

- alert: GitOpsLonghornBackupStuck
  expr: |
    longhorn_backup_state == 2  # Correct - 2 = InProgress
```

**State mapping:** 0=New, 1=Pending, 2=InProgress, **3=Completed**, 4=Error, 5=Unknown

### References
- [Longhorn Metrics Documentation](https://longhorn.io/docs/1.9.2/monitoring/metrics/)
- [GitHub Issue #4521 - Backup State Values](https://github.com/longhorn/longhorn/issues/4521)
- [Prometheus Operator PrometheusRule CRD](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PrometheusRule)

## Testing

Fleet GitOps will deploy this automatically upon merge. Verify:
- ServiceMonitor created: `kubectl get servicemonitor -n longhorn-system longhorn-prometheus-servicemonitor`
- Prometheus scraping targets: Check Prometheus UI → Targets → longhorn-system namespace (2 healthy targets expected)
- PrometheusRule loaded: `kubectl get prometheusrule -n monitoring longhorn-storage-alerts`
- Alerts evaluating: Prometheus UI → Alerts → filter "longhorn" (all should be inactive in healthy cluster)
- Metrics available: Query `longhorn_volume_robustness`, `longhorn_volume_state`, `longhorn_backup_state` in Prometheus

**Expected healthy cluster state:**
- 0 firing Longhorn alerts
- 6 rule groups with 19 total alert rules loaded
- All alerts in "inactive" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)