### PR TITLE
feat: add flightsim-mcp Fleet manifests for K8s deployment

### DIFF
--- a/charts/flightsim-mcp/deployment.yaml
+++ b/charts/flightsim-mcp/deployment.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flightsim-mcp
+  namespace: flightsim-mcp
+spec:
+  selector:
+    matchLabels:
+      app: flightsim-mcp
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: flightsim-mcp
+    spec:
+      containers:
+        - name: flightsim-mcp
+          image: ghcr.io/eythan-decker/flightsim-mcp:latest
+          env:
+            - name: MCP_TRANSPORT
+              value: "http"
+            - name: MCP_HTTP_ADDR
+              value: ":8080"
+            - name: SIMCONNECT_HOST
+              value: "192.168.0.44"
+            - name: SIMCONNECT_PORT
+              value: "4500"
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5

--- a/charts/flightsim-mcp/fleet.yaml
+++ b/charts/flightsim-mcp/fleet.yaml
@@ -1,0 +1,1 @@
+defaultNamespace: flightsim-mcp

--- a/charts/flightsim-mcp/service.yaml
+++ b/charts/flightsim-mcp/service.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flightsim-mcp
+  namespace: flightsim-mcp
+spec:
+  selector:
+    app: flightsim-mcp
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: flightsim-mcp
+  namespace: flightsim-mcp
+  annotations:
+    kubernetes.io/ingress.class: traefik-external
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`flightsim-mcp.moria-lab.com`)
+      kind: Rule
+      services:
+        - name: flightsim-mcp
+          port: 8080
+  tls: {}

--- a/charts/kube-prometheus-stack/overlays/dev/prometheusrules/longhorn-storage-alerts.yaml
+++ b/charts/kube-prometheus-stack/overlays/dev/prometheusrules/longhorn-storage-alerts.yaml
@@ -74,25 +74,25 @@ spec:
       rules:
         - alert: GitOpsLonghornVolumeUsageHigh
           expr: |
-            (longhorn_volume_actual_size_bytes / longhorn_volume_capacity_bytes) * 100 > 80
+            (kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes) * 100 > 80
           for: 10m
           labels:
             severity: warning
             component: longhorn
           annotations:
-            summary: "Longhorn volume {{ $labels.volume }} is {{ $value | humanizePercentage }} full"
-            description: "Volume {{ $labels.volume }} is at {{ $value | humanizePercentage }} capacity. Consider expanding or cleaning up data."
+            summary: "Longhorn volume {{ $labels.persistentvolumeclaim }} in {{ $labels.namespace }} is {{ $value | humanizePercentage }} full"
+            description: "PVC {{ $labels.persistentvolumeclaim }} in {{ $labels.namespace }} is at {{ $value | humanizePercentage }} capacity. Consider expanding or cleaning up data."
 
         - alert: GitOpsLonghornVolumeUsageCritical
           expr: |
-            (longhorn_volume_actual_size_bytes / longhorn_volume_capacity_bytes) * 100 > 90
+            (kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes) * 100 > 90
           for: 5m
           labels:
             severity: critical
             component: longhorn
           annotations:
-            summary: "Longhorn volume {{ $labels.volume }} is CRITICALLY full at {{ $value | humanizePercentage }}"
-            description: "Volume {{ $labels.volume }} is at {{ $value | humanizePercentage }} capacity. IMMEDIATE expansion or cleanup required to prevent write failures."
+            summary: "Longhorn volume {{ $labels.persistentvolumeclaim }} in {{ $labels.namespace }} is CRITICALLY full at {{ $value | humanizePercentage }}"
+            description: "PVC {{ $labels.persistentvolumeclaim }} in {{ $labels.namespace }} is at {{ $value | humanizePercentage }} capacity. IMMEDIATE expansion or cleanup required to prevent write failures."
 
         - alert: GitOpsLonghornNodeStorageWarning
           expr: |


### PR DESCRIPTION
## Summary

Adds Fleet GitOps manifests to deploy flightsim-mcp as a K8s service, and fixes false-positive Longhorn volume usage alerts.

## Changes

- **charts/flightsim-mcp/fleet.yaml**: Fleet config with `defaultNamespace: flightsim-mcp`
- **charts/flightsim-mcp/deployment.yaml**: Single-replica deployment with `ghcr.io/eythan-decker/flightsim-mcp:latest`, resource limits (50m/32Mi → 200m/128Mi), liveness/readiness probes, SimConnect env vars pointing to `192.168.0.44:4500`
- **charts/flightsim-mcp/service.yaml**: ClusterIP service on port 8080 + Traefik IngressRoute for `flightsim-mcp.moria-lab.com` via `websecure` entrypoint
- **charts/kube-prometheus-stack/overlays/dev/prometheusrules/longhorn-storage-alerts.yaml**: Fix VolumeUsageHigh/Critical alerts to use kubelet filesystem metrics instead of Longhorn block-level metrics

## Technical Details

### Probe Design
- **Liveness** (`GET /health`): Always 200 — avoids restarting pod when SimConnect is unreachable (app handles reconnection with exponential backoff)
- **Readiness** (`GET /ready`): Returns 503 when no SimConnect data received or data is stale — removes pod from endpoints until sim is actively sending data

### Environment Variables
| Variable | Value | Purpose |
|----------|-------|---------|
| `MCP_TRANSPORT` | `http` | Enable HTTP transport (default is stdio) |
| `MCP_HTTP_ADDR` | `:8080` | Listen address |
| `SIMCONNECT_HOST` | `192.168.0.44` | MSFS PC on local network |
| `SIMCONNECT_PORT` | `4500` | SimConnect TCP port |

### Longhorn Alert Fix
The `GitOpsLonghornVolumeUsageHigh` and `GitOpsLonghornVolumeUsageCritical` alerts were using `longhorn_volume_actual_size_bytes` which tracks Longhorn's internal block allocation (including stale/deleted data blocks), not actual filesystem usage. This caused false positives — e.g. the Loki volume (`storage-loki-0`) was reported at 80% while `df` inside the pod showed only 29% usage.

**Before:** `longhorn_volume_actual_size_bytes / longhorn_volume_capacity_bytes`
**After:** `kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes`

`kubelet_volume_stats_*` metrics come from the kubelet's CSI volume stats collector and report true filesystem-level usage, matching what `df` shows inside the pod.

### References
- Companion PR in [flightsim-mcp](https://github.com/eythan-decker/flightsim-mcp) adds the HTTP transport and container image

## Testing

Fleet GitOps will deploy this automatically upon merge. Verify:
- Pod starts and liveness probe passes (200 on `/health`)
- Readiness returns 503 initially (no SimConnect data)
- With MSFS running at 192.168.0.44, readiness flips to 200
- `curl https://flightsim-mcp.moria-lab.com/health` returns 200 through Traefik
- `GitOpsLonghornVolumeUsageHigh` alert clears after Prometheus reloads the updated rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)