### PR TITLE
feat: add Traefik Prometheus monitoring with ServiceMonitor and 9 alerts

### DIFF
--- a/charts/kube-prometheus-stack/overlays/dev/kustomization.yaml
+++ b/charts/kube-prometheus-stack/overlays/dev/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ingress.yaml
   - prometheusrules/gitops-cert-manager-expiration-prometheus.yaml
   - prometheusrules/longhorn-storage-alerts.yaml
+  - prometheusrules/traefik-alerts.yaml
   - alertmanagerconfig-discord.yaml 

--- a/charts/kube-prometheus-stack/overlays/dev/prometheusrules/traefik-alerts.yaml
+++ b/charts/kube-prometheus-stack/overlays/dev/prometheusrules/traefik-alerts.yaml
@@ -1,0 +1,120 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: traefik-alerts
+  namespace: monitoring
+  labels:
+    prometheus: kube-prometheus-stack-prometheus
+    role: alert-rules
+spec:
+  groups:
+    - name: traefik-availability
+      interval: 30s
+      rules:
+        - alert: GitOpsTraefikDown
+          expr: |
+            up{job="traefik-metrics"} == 0
+          for: 2m
+          labels:
+            severity: critical
+            component: traefik
+          annotations:
+            summary: "Traefik instance {{ $labels.instance }} is DOWN"
+            description: "Traefik instance {{ $labels.instance }} in namespace {{ $labels.namespace }} has been down for 2 minutes. Ingress traffic may be impacted."
+
+        - alert: GitOpsTraefikHighReplicaFailure
+          expr: |
+            sum(kube_deployment_status_replicas_available{deployment="traefik", namespace="traefik-system"}) < 2
+          for: 5m
+          labels:
+            severity: critical
+            component: traefik
+          annotations:
+            summary: "Traefik has fewer than 2 replicas available"
+            description: "Traefik deployment has {{ $value }} replicas available (expected 3). High availability is compromised."
+
+    - name: traefik-error-rates
+      interval: 1m
+      rules:
+        - alert: GitOpsTraefikHigh4xxErrorRate
+          expr: |
+            (sum(rate(traefik_service_requests_total{code=~"4.."}[5m])) by (service) / sum(rate(traefik_service_requests_total[5m])) by (service)) * 100 > 10
+          for: 5m
+          labels:
+            severity: warning
+            component: traefik
+          annotations:
+            summary: "High 4xx error rate on service {{ $labels.service }}"
+            description: "Service {{ $labels.service }} has {{ $value | humanizePercentage }} 4xx error rate over the last 5 minutes."
+
+        - alert: GitOpsTraefikHigh5xxErrorRate
+          expr: |
+            (sum(rate(traefik_service_requests_total{code=~"5.."}[5m])) by (service) / sum(rate(traefik_service_requests_total[5m])) by (service)) * 100 > 5
+          for: 5m
+          labels:
+            severity: critical
+            component: traefik
+          annotations:
+            summary: "CRITICAL: High 5xx error rate on service {{ $labels.service }}"
+            description: "Service {{ $labels.service }} has {{ $value | humanizePercentage }} 5xx error rate. Backend application is failing."
+
+        - alert: GitOpsTraefikEntrypointHigh5xxRate
+          expr: |
+            (sum(rate(traefik_entrypoint_requests_total{code=~"5.."}[5m])) by (entrypoint) / sum(rate(traefik_entrypoint_requests_total[5m])) by (entrypoint)) * 100 > 3
+          for: 5m
+          labels:
+            severity: warning
+            component: traefik
+          annotations:
+            summary: "High 5xx error rate on entrypoint {{ $labels.entrypoint }}"
+            description: "Entrypoint {{ $labels.entrypoint }} has {{ $value | humanizePercentage }} 5xx error rate. Multiple backends may be failing."
+
+    - name: traefik-latency
+      interval: 1m
+      rules:
+        - alert: GitOpsTraefikHighLatency
+          expr: |
+            histogram_quantile(0.95, sum(rate(traefik_service_request_duration_seconds_bucket[5m])) by (service, le)) > 2
+          for: 10m
+          labels:
+            severity: warning
+            component: traefik
+          annotations:
+            summary: "High latency on service {{ $labels.service }}"
+            description: "Service {{ $labels.service }} p95 latency is {{ $value }}s (threshold: 2s). Users may experience slow response times."
+
+        - alert: GitOpsTraefikVeryHighLatency
+          expr: |
+            histogram_quantile(0.95, sum(rate(traefik_service_request_duration_seconds_bucket[5m])) by (service, le)) > 5
+          for: 5m
+          labels:
+            severity: critical
+            component: traefik
+          annotations:
+            summary: "CRITICAL: Very high latency on service {{ $labels.service }}"
+            description: "Service {{ $labels.service }} p95 latency is {{ $value }}s. Severe performance degradation."
+
+        - alert: GitOpsTraefikEntrypointHighLatency
+          expr: |
+            histogram_quantile(0.95, sum(rate(traefik_entrypoint_request_duration_seconds_bucket[5m])) by (entrypoint, le)) > 3
+          for: 10m
+          labels:
+            severity: warning
+            component: traefik
+          annotations:
+            summary: "High latency on entrypoint {{ $labels.entrypoint }}"
+            description: "Entrypoint {{ $labels.entrypoint }} p95 latency is {{ $value }}s. Overall ingress performance is degraded."
+
+    - name: traefik-traffic-anomalies
+      interval: 1m
+      rules:
+        - alert: GitOpsTraefikHighRequestRate
+          expr: |
+            sum(rate(traefik_service_requests_total[1m])) > 100
+          for: 5m
+          labels:
+            severity: info
+            component: traefik
+          annotations:
+            summary: "Unusually high request rate detected"
+            description: "Traefik is handling {{ $value }} requests/sec. This may indicate a traffic spike, DDoS attempt, or bot activity."

--- a/charts/traefik/overlays/dev/kustomization.yaml
+++ b/charts/traefik/overlays/dev/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - tlsstore.yaml
+- servicemonitor.yaml

--- a/charts/traefik/overlays/dev/servicemonitor.yaml
+++ b/charts/traefik/overlays/dev/servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: traefik-metrics
+  namespace: traefik-system
+  labels:
+    app.kubernetes.io/name: traefik
+    app.kubernetes.io/instance: traefik
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+      app.kubernetes.io/instance: traefik-traefik-system
+  endpoints:
+    - port: metrics
+      interval: 30s
+      scheme: http

--- a/charts/traefik/values.yaml
+++ b/charts/traefik/values.yaml
@@ -28,6 +28,12 @@ ports:
         to: websecure
         scheme: https
         permanent: true
+  metrics:
+    expose:
+      default: false
+    exposedPort: 9100
+    port: 9100
+    protocol: TCP
 
 ingressRoute:
   dashboard:

--- a/charts/traefik/values.yaml
+++ b/charts/traefik/values.yaml
@@ -29,10 +29,10 @@ ports:
         scheme: https
         permanent: true
   metrics:
-    expose:
-      default: false
-    exposedPort: 9100
     port: 9100
+    expose:
+      default: true
+    exposedPort: 9100
     protocol: TCP
 
 ingressRoute:

--- a/charts/traefik/values.yaml
+++ b/charts/traefik/values.yaml
@@ -85,7 +85,3 @@ metrics:
     addEntryPointsLabels: true
     addRoutersLabels: true
     addServicesLabels: true
-  serviceMonitor:
-    enabled: true
-    metricRelabelings: []
-    relabelings: []

--- a/charts/traefik/values.yaml
+++ b/charts/traefik/values.yaml
@@ -77,3 +77,15 @@ extraObjects:
   spec:
     basicAuth:
       secret: traefik-dashboard-auth-secret
+
+# Prometheus metrics configuration
+metrics:
+  prometheus:
+    entryPoint: metrics
+    addEntryPointsLabels: true
+    addRoutersLabels: true
+    addServicesLabels: true
+  serviceMonitor:
+    enabled: true
+    metricRelabelings: []
+    relabelings: []


### PR DESCRIPTION
## Summary

Enables Prometheus metrics collection for Traefik and adds 9 alerting rules covering availability, error rates, latency, and traffic anomalies. Provides observability into ingress health and performance.

## Changes

- **charts/traefik/values.yaml**: Add metrics port (9100) exposure and Prometheus metrics configuration with entrypoint, router, and service labels
- **charts/traefik/overlays/dev/servicemonitor.yaml**: New ServiceMonitor for Prometheus to scrape Traefik metrics on port 9100
- **charts/traefik/overlays/dev/kustomization.yaml**: Add servicemonitor.yaml to kustomize resources
- **charts/kube-prometheus-stack/overlays/dev/prometheusrules/traefik-alerts.yaml**: New PrometheusRule with 9 alerts across 4 groups
- **charts/kube-prometheus-stack/overlays/dev/kustomization.yaml**: Add traefik-alerts.yaml to kustomize resources

## Technical Details

### Alert Groups

| Group | Alerts | Severity |
|-------|--------|----------|
| traefik-availability | GitOpsTraefikDown, GitOpsTraefikHighReplicaFailure | critical |
| traefik-error-rates | GitOpsTraefikHigh4xxErrorRate, GitOpsTraefikHigh5xxErrorRate, GitOpsTraefikEntrypointHigh5xxRate | warning/critical |
| traefik-latency | GitOpsTraefikHighLatency, GitOpsTraefikVeryHighLatency, GitOpsTraefikEntrypointHighLatency | warning/critical |
| traefik-traffic-anomalies | GitOpsTraefikHighRequestRate | info |

All alerts follow the `GitOps` naming convention and use the required `prometheus: kube-prometheus-stack-prometheus` label.

## Testing

Fleet GitOps will deploy this automatically upon merge. Verify:
- Traefik metrics endpoint is accessible on port 9100
- ServiceMonitor target appears in Prometheus UI under targets
- PrometheusRule alerts appear in Grafana/AlertManager
- No false-positive alerts firing after initial deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)